### PR TITLE
Make loginctl-linger work on a freshly installed system

### DIFF
--- a/nixos-config/modules/loginctl-linger.nix
+++ b/nixos-config/modules/loginctl-linger.nix
@@ -19,10 +19,9 @@ let
       (sort (a: b: a < b) lingeringUsers))); # this sorting is important for `comm` to work correctly
 
   updateLingering = pkgs.writeScript "update-lingering" ''
-    if [ -e ${dataDir} ] ; then
-      ls ${dataDir} | sort | comm -3 -1 ${lingeringUsersFile} - | xargs -r ${pkgs.systemd}/bin/loginctl disable-linger
-      ls ${dataDir} | sort | comm -3 -2 ${lingeringUsersFile} - | xargs -r ${pkgs.systemd}/bin/loginctl  enable-linger
-    fi
+    lingering=$(ls ${dataDir} 2> /dev/null | sort)
+    echo "$lingering" | comm -3 -1 ${lingeringUsersFile} - | xargs -r ${pkgs.systemd}/bin/loginctl disable-linger
+    echo "$lingering" | comm -3 -2 ${lingeringUsersFile} - | xargs -r ${pkgs.systemd}/bin/loginctl enable-linger
   '';
 
 in


### PR DESCRIPTION
Initially, the data dir `/var/lib/systemd/linger` doesn't exist,
so don't quit in this case.